### PR TITLE
Added automatic msbuild path with two new options.

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -117,7 +117,7 @@ module.exports = function(grunt) {
     }
     
     function buildPath (version, processor) {
-      processor = 'Framework' + processor;
+      processor = 'Framework' + (processor === 64 ? processor : '');
       version = versions[version];
       if (!version) {
         grunt.fatal('Invaild .NET framework version "' + version + '"');


### PR DESCRIPTION
Added two new options to get the msbuild path automatic. It default's to .NET 4.0 and x86 framework directory.

The first one is to determine the .NET version. Can choose from 1.0, 1.1, 2.0, 3.5 and 4.0.

``` js
msbuild: {
  dev: {
    ...
    version: 4.0
    ...
  }
}
```

The second option is for determine the processor. Setting the option value to 64 change the msbuild path to the 64 framework directory.

``` js
msbuild: {
  dev: {
    ...
    processor: 64
    ...
  }
}
```
