### PR TITLE
added nologo switch to options

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -28,7 +28,8 @@ module.exports = function (grunt) {
             failOnError: true,
             verbosity: 'normal',
             processor: '',
-            version: 4.0
+            version: 4.0,
+            nologo: true
         });
 
         if (!options.projectConfiguration) {
@@ -99,6 +100,10 @@ module.exports = function (grunt) {
 
         var args = ' /target:' + options.targets;
         args += ' /verbosity:' + options.verbosity;
+        
+        if(options.nologo){
+            args += ' /nologo';
+        }
 
         if (options.maxCpuCount) {
             grunt.verbose.writeln('Using maxcpucount:' + '' + options.maxCpuCount.cyan);


### PR DESCRIPTION
Just adding an option to pass the /nologo switch. Helps keep clutter out of the build messages.
