### PR TITLE
Added the optional parameter for defining platform

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -115,6 +115,10 @@ module.exports = function(grunt) {
 
         args.push('/property:Configuration=' + options.projectConfiguration);
 
+        if (options.platform) {
+            args.push('/p:Platform=' + options.platform);
+        }
+
         for (var buildArg in options.buildParameters) {
             args.push('/property:' + buildArg + '=' + options.buildParameters[buildArg]);
         }


### PR DESCRIPTION
We're building a Windows Store app for x86, x64 and ARM. We needed this parameter, if ain't a problem with you, please merge and publish.
