### PR TITLE
Support for latest MSBuild versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For more information, see [MSBuild Command-Line Reference](http://msdn.microsoft
 ## MSBuild version selection
 Pass a version parameter to the task options as shown above to select a specific MSBuild version.
 
-The version number is used to look up the .NET version and find the .NET Framework directory location on disk. The following version mappings are used:
+The version number is used to look up the MSBuild executable. Old MSBuild versions are installed to the corresponding .NET Framework directory (under `C:\Windows\Microsoft.NET\Framework`). Recent MSBuild versions are installed to program files (`C:\Program Files (x86)\MSBuild`). The following version mappings are used:
 
 |Version| .NET Framework directory|
 |-------|-------------------------|
@@ -69,10 +69,15 @@ The version number is used to look up the .NET version and find the .NET Framewo
 |3.5|3.5|
 |4.0|4.0.30319|
 
-If a version is not passed the task will attempt to locate version 12 of MSBuild which is installed with Visual Studio 2013, and will then fallback to 4.0
+|Version|MSBuild directory|
+|-------|-----------------|
+|12.0|12.0|
+|14.0|14.0|
+
+If a version is not passed the task will attempt to locate version 12 of MSBuild which is installed with Visual Studio 2013, and will then fallback to 4.0.
 
 ## XBuild
-If this task is run on OS X or Linux it will assume that xbuild is in the path and use that instead of MSBuild
+If this task is run on OS X or Linux it will assume that xbuild is in the path and use that instead of MSBuild.
 
 ## Contributing
 All contributions welcome :) Add to the VS integration tests for any new or changed functionality if possible.

--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -14,7 +14,9 @@ module.exports = function(grunt) {
         1.1: '1.1.4322',
         2.0: '2.0.50727',
         3.5: '3.5',
-        4.0: '4.0.30319'
+        4.0: '4.0.30319',
+        12.0: '12.0',
+        14.0: '14.0'
     };
 
     grunt.registerMultiTask('msbuild', 'Run MSBuild tasks', function() {
@@ -168,10 +170,15 @@ module.exports = function(grunt) {
         var specificVersion = versions[version];
 
         if (!specificVersion) {
-            grunt.fatal('Unrecognised .NET framework version "' + version + '"');
+            grunt.fatal('Unrecognised MSBuild version "' + version + '"');
         }
 
-        var buildExecutablePath = path.join(process.env.WINDIR, 'Microsoft.Net', processor, 'v' + specificVersion, 'MSBuild.exe');
+        if (version < 12) {
+            var buildExecutablePath = path.join(process.env.WINDIR, 'Microsoft.Net', processor, 'v' + specificVersion, 'MSBuild.exe');
+        } else {
+            var programFiles = process.env['ProgramFiles(x86)'] || process.env.PROGRAMFILES;
+            var buildExecutablePath = path.join(programFiles, 'MSBuild', specificVersion, 'Bin', 'MSBuild.exe');
+        }
 
         grunt.verbose.writeln('Using MSBuild at:' + buildExecutablePath.cyan);
 

--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -149,6 +149,10 @@ module.exports = function(grunt) {
             return 'xbuild';
         }
 
+        // convert to numbers if correct strings
+        version = isNaN(version) ? version : parseFloat(version);
+        processor = isNaN(processor) ? processor : parseFloat(processor);
+
         var programFiles = process.env['ProgramFiles(x86)'] || process.env.PROGRAMFILES;
 
         if (!version) {

--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -164,7 +164,7 @@ module.exports = function(grunt) {
 
                 if (msbuildVersions.length > 0) {
                     // set latest installed msbuild version
-                    version = parseInt(msbuildVersions[msbuildVersions.length - 1]);
+                    version = parseFloat(msbuildVersions[msbuildVersions.length - 1]);
                 }
             }
         }

--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -169,8 +169,6 @@ module.exports = function(grunt) {
             }
         }
 
-        processor = 'Framework' + (processor === 64 ? processor : '');
-
         var specificVersion = versions[version];
 
         if (!specificVersion) {
@@ -178,9 +176,11 @@ module.exports = function(grunt) {
         }
 
         if (version < 12) {
-            var buildExecutablePath = path.join(process.env.WINDIR, 'Microsoft.Net', processor, 'v' + specificVersion, 'MSBuild.exe');
+            var frameworkDir = 'Framework' + (processor === 64 ? processor : '');
+            var buildExecutablePath = path.join(process.env.WINDIR, 'Microsoft.Net', frameworkDir, 'v' + specificVersion, 'MSBuild.exe');
         } else {
-            var buildExecutablePath = path.join(programFiles, 'MSBuild', specificVersion, 'Bin', 'MSBuild.exe');
+            var x64Dir = processor === 64 ? 'amd64' : '';
+            var buildExecutablePath = path.join(programFiles, 'MSBuild', specificVersion, 'Bin', x64Dir, 'MSBuild.exe');
         }
 
         grunt.verbose.writeln('Using MSBuild at:' + buildExecutablePath.cyan);

--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -149,19 +149,23 @@ module.exports = function(grunt) {
             return 'xbuild';
         }
 
-        if (!version) {
-            var msBuild12x86Path = 'C:\\Program Files (x86)\\MSBuild\\12.0\\Bin\\MSBuild.exe';
-            var msBuild12x64Path = 'C:\\Program Files\\MSBuild\\12.0\\Bin\\MSBuild.exe';
+        var programFiles = process.env['ProgramFiles(x86)'] || process.env.PROGRAMFILES;
 
-            if (fs.existsSync(msBuild12x86Path)) {
-                grunt.verbose.writeln('Using MSBuild at:', msBuild12x86Path.cyan);
-                return msBuild12x86Path;
-            } else if (fs.existsSync(msBuild12x64Path)) {
-                grunt.verbose.writeln('Using MSBuild at:', msBuild12x64Path.cyan);
-                return msBuild12x64Path;
-            } else {
-                // Fallback to version 4.0
-                version = 4.0;
+        if (!version) {
+            version = 4.0; // default fallback to version 4.0
+
+            var msbuildDir = path.join(programFiles, 'MSBuild');
+
+            if (fs.existsSync(msbuildDir)) {
+                var msbuildVersions = fs.readdirSync(msbuildDir)
+                    .filter(function(entryName) {
+                        return entryName.indexOf('1') === 0;
+                    });
+
+                if (msbuildVersions.length > 0) {
+                    // set latest installed msbuild version
+                    version = parseInt(msbuildVersions[msbuildVersions.length - 1]);
+                }
             }
         }
 
@@ -176,7 +180,6 @@ module.exports = function(grunt) {
         if (version < 12) {
             var buildExecutablePath = path.join(process.env.WINDIR, 'Microsoft.Net', processor, 'v' + specificVersion, 'MSBuild.exe');
         } else {
-            var programFiles = process.env['ProgramFiles(x86)'] || process.env.PROGRAMFILES;
             var buildExecutablePath = path.join(programFiles, 'MSBuild', specificVersion, 'Bin', 'MSBuild.exe');
         }
 


### PR DESCRIPTION
Latest MSBuild versions are [installed separately from .NET Framework](http://msdn.microsoft.com/en-us/library/hh162058.aspx) and use Visual Studio versioning. This pull request adds possibility to use MSBuild 12 and 14 explicitly or use the latest installed version automatically.

As a small addition I added support for string values for `version` and `processor` options, because this is not obvious for the end user what js type is required here and the error message just tells that version is invalid.