### PR TITLE
Absolute Paths Support

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -113,7 +113,7 @@ module.exports = function(grunt) {
         var args = [];
 
         if (src) {
-            var projectPath = path.normalize(path.resolve() + '/' + src);
+            var projectPath = path.normalize(src);
 
             args.push(projectPath);
         }


### PR DESCRIPTION
Hi @stevewillcock, here's a patch that means grunt-msbuild will support both relative and absolute project paths to solve issue #6.