### PR TITLE
Don't use unsupported maxcpucount switch with xbuild

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -125,8 +125,11 @@ module.exports = function(grunt) {
         }
 
         if (options.maxCpuCount) {
-            grunt.verbose.writeln('Using maxcpucount:', +options.maxCpuCount);
-            args.push('/maxcpucount:' + options.maxCpuCount);
+            // maxcpucount is not supported by xbuild
+            if (process.platform === 'win32') {
+                grunt.verbose.writeln('Using maxcpucount:', +options.maxCpuCount);
+                args.push('/maxcpucount:' + options.maxCpuCount);
+            }
         }
 
 	if (options.consoleLoggerParameters) {


### PR DESCRIPTION
`maxcpucount` switch is not supported by xbuild (current 12.0 version) and produces the following error if specified:
```
MSBUILD: error MSBUILD0004: Too many project files specified
```
This patch omits the switch on non win32 platforms.