### PR TITLE
VisualStudioVersion option

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
         }
 
         if (options.visualStudioVersion) {
-            args.push('/p:VisualStudioVersion=' + options.visualStudioVersion);
+            args.push('/p:VisualStudioVersion=' + options.visualStudioVersion + '.0');
         }
 
         for (var buildArg in options.buildParameters) {

--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -153,6 +153,10 @@ module.exports = function (grunt) {
             args.push('/nodeReuse:false');
         }
 
+        if (options.visualStudioVersion) {
+            args.push('/p:VisualStudioVersion=' + options.visualStudioVersion);
+        }
+
         for (var buildArg in options.buildParameters) {
             var p = '/property:' + buildArg + '=' + options.buildParameters[buildArg];
             grunt.verbose.writeln('setting property: ' + p);


### PR DESCRIPTION
The VisualStudioVersion option changes the "ToolsVersion" used to build the projects in the solution. I want this option because it changes the value of $VisualStudioVersion in a csproject. MsBuild kept trying to use version 10 no matter what I did. I added this option, set its value to 15, and now it finds the path like it should.

Example from csproj:

```
<Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.targets" />
```